### PR TITLE
Handle multiple OTP types in verification flow

### DIFF
--- a/app/_actions/auth.ts
+++ b/app/_actions/auth.ts
@@ -272,18 +272,26 @@ export const verifyOtpAction = action
 
     try {
       const attemptTypes: any[] = ["phone_change", "signup", "sms", "recovery"];
-      let data: any = null; let lastError: any = null;
+      let data: any = null;
+      let lastError: any = null;
+
       for (const type of attemptTypes) {
         const { data: d, error } = await supabase.auth.verifyOtp({
           phone,
           token,
           type,
         } as any);
-        if (!error && d?.user) { data = d; lastError = null; break; }
-        lastError = error;
-        // Stop early if error explicitly indicates expired/invalid to avoid rate issues
-        if (error && /expired|invalid/i.test(error.message)) break;
+
+        if (!error && d?.user) {
+          data = d;
+          break;
+        }
+
+        if (error) {
+          lastError = error;
+        }
       }
+
       if (lastError && !data) {
         const msg = /expired/i.test(lastError.message)
           ? 'OTP_EXPIRED'


### PR DESCRIPTION
## Summary
- Avoid prematurely aborting OTP verification; iterate through possible OTP types and check all before failing.

## Testing
- `pnpm lint` *(fails: many existing lint errors)*
- `pnpm build` *(fails: could not fetch required fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68bebdb6d7f88329b3c01b25e9c188f0